### PR TITLE
PT-4135: Use assets from newly created module instead of the platform

### DIFF
--- a/src/VirtoCommerce.SitemapsModule.Core/VirtoCommerce.SitemapsModule.Core.csproj
+++ b/src/VirtoCommerce.SitemapsModule.Core/VirtoCommerce.SitemapsModule.Core.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-        <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.30.0" />
+        <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.81.0" />
         <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1.0" />
     </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.SitemapsModule.Data/Services/SitemapItemRecordProviders/StaticContentSitemapItemRecordProvider.cs
+++ b/src/VirtoCommerce.SitemapsModule.Data/Services/SitemapItemRecordProviders/StaticContentSitemapItemRecordProvider.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using VirtoCommerce.ContentModule.Core.Services;
-using VirtoCommerce.Platform.Core.Assets;
+using VirtoCommerce.AssetsModule.Core.Assets;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.ExportImport;
 using VirtoCommerce.Platform.Core.Settings;

--- a/src/VirtoCommerce.SitemapsModule.Data/VirtoCommerce.SitemapsModule.Data.csproj
+++ b/src/VirtoCommerce.SitemapsModule.Data/VirtoCommerce.SitemapsModule.Data.csproj
@@ -27,7 +27,7 @@
         <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1.0" />
         <PackageReference Include="VirtoCommerce.Tools" Version="3.0.0-rc.5" />
         <PackageReference Include="YamlDotNet" Version="5.2.1" />
-        <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.0.0" />        
+        <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="1.0.0" />        
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\VirtoCommerce.SitemapsModule.Core\VirtoCommerce.SitemapsModule.Core.csproj" />

--- a/src/VirtoCommerce.SitemapsModule.Data/VirtoCommerce.SitemapsModule.Data.csproj
+++ b/src/VirtoCommerce.SitemapsModule.Data/VirtoCommerce.SitemapsModule.Data.csproj
@@ -9,24 +9,25 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.8">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.13" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.13">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.8">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.13">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1.0" />
-        <PackageReference Include="VirtoCommerce.ContentModule.Core" Version="3.1.0" />
+        <PackageReference Include="VirtoCommerce.ContentModule.Core" Version="3.14.0" />
         <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1.0" />
-        <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.30.0" />
-        <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.30.0" />
+        <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.81.0" />
+        <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.81.0" />
         <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1.0" />
         <PackageReference Include="VirtoCommerce.Tools" Version="3.0.0-rc.5" />
         <PackageReference Include="YamlDotNet" Version="5.2.1" />
+        <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.0.0" />        
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\VirtoCommerce.SitemapsModule.Core\VirtoCommerce.SitemapsModule.Core.csproj" />

--- a/src/VirtoCommerce.SitemapsModule.Data/VirtoCommerce.SitemapsModule.Data.csproj
+++ b/src/VirtoCommerce.SitemapsModule.Data/VirtoCommerce.SitemapsModule.Data.csproj
@@ -19,7 +19,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-        <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1.0" />
+        <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.78.0" />
         <PackageReference Include="VirtoCommerce.ContentModule.Core" Version="3.14.0" />
         <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1.0" />
         <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.81.0" />

--- a/src/VirtoCommerce.SitemapsModule.Web/Controllers/Api/SitemapsModuleApiController.cs
+++ b/src/VirtoCommerce.SitemapsModule.Web/Controllers/Api/SitemapsModuleApiController.cs
@@ -12,7 +12,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using VirtoCommerce.Platform.Core;
-using VirtoCommerce.Platform.Core.Assets;
+using VirtoCommerce.AssetsModule.Core.Assets;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Exceptions;
 using VirtoCommerce.Platform.Core.ExportImport;

--- a/src/VirtoCommerce.SitemapsModule.Web/VirtoCommerce.SitemapsModule.Web.csproj
+++ b/src/VirtoCommerce.SitemapsModule.Web/VirtoCommerce.SitemapsModule.Web.csproj
@@ -17,7 +17,8 @@
   <ItemGroup>
     <PackageReference Include="Hangfire" Version="1.7.9" />
     <PackageReference Include="System.IO.Packaging" Version="4.7.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.30.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.81.0" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.SitemapsModule.Core\VirtoCommerce.SitemapsModule.Core.csproj" />

--- a/src/VirtoCommerce.SitemapsModule.Web/VirtoCommerce.SitemapsModule.Web.csproj
+++ b/src/VirtoCommerce.SitemapsModule.Web/VirtoCommerce.SitemapsModule.Web.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Hangfire" Version="1.7.9" />
     <PackageReference Include="System.IO.Packaging" Version="4.7.0" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.81.0" />
-    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.0.0" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.SitemapsModule.Core\VirtoCommerce.SitemapsModule.Core.csproj" />

--- a/src/VirtoCommerce.SitemapsModule.Web/module.manifest
+++ b/src/VirtoCommerce.SitemapsModule.Web/module.manifest
@@ -22,7 +22,7 @@
     <moduleType>VirtoCommerce.SitemapsModule.Web.Module, VirtoCommerce.SitemapsModule.Web</moduleType>
     <dependencies>
         <dependency id="VirtoCommerce.Core" version="3.0.0" />
-        <dependency id="VirtoCommerce.Catalog" version="3.0.0" />
+        <dependency id="VirtoCommerce.Catalog" version="3.78.0" />
         <dependency id="VirtoCommerce.Content" version="3.14.0" />
         <dependency id="VirtoCommerce.Customer" version="3.0.0" />
         <dependency id="VirtoCommerce.Store" version="3.0.0" />

--- a/src/VirtoCommerce.SitemapsModule.Web/module.manifest
+++ b/src/VirtoCommerce.SitemapsModule.Web/module.manifest
@@ -3,7 +3,7 @@
     <id>VirtoCommerce.Sitemaps</id>
     <version>3.8.0</version>
     <version-tag />
-    <platformVersion>3.61.0-alpha.11922</platformVersion>
+    <platformVersion>3.81</platformVersion>
     <title>Sitemaps module</title>
     <description>Sitemaps generation management for stores</description>
     <authors>
@@ -23,9 +23,10 @@
     <dependencies>
         <dependency id="VirtoCommerce.Core" version="3.0.0" />
         <dependency id="VirtoCommerce.Catalog" version="3.0.0" />
-        <dependency id="VirtoCommerce.Content" version="3.0.0" />
+        <dependency id="VirtoCommerce.Content" version="3.14.0" />
         <dependency id="VirtoCommerce.Customer" version="3.0.0" />
         <dependency id="VirtoCommerce.Store" version="3.0.0" />
+        <dependency id="VirtoCommerce.Assets" version="3.0.0" />
     </dependencies>
     <groups>
         <group>commerce</group>

--- a/src/VirtoCommerce.SitemapsModule.Web/module.manifest
+++ b/src/VirtoCommerce.SitemapsModule.Web/module.manifest
@@ -26,7 +26,7 @@
         <dependency id="VirtoCommerce.Content" version="3.14.0" />
         <dependency id="VirtoCommerce.Customer" version="3.0.0" />
         <dependency id="VirtoCommerce.Store" version="3.0.0" />
-        <dependency id="VirtoCommerce.Assets" version="3.0.0" />
+        <dependency id="VirtoCommerce.Assets" version="1.0.0" />
     </dependencies>
     <groups>
         <group>commerce</group>

--- a/src/VirtoCommerce.SitemapsModule.Web/module.manifest
+++ b/src/VirtoCommerce.SitemapsModule.Web/module.manifest
@@ -3,7 +3,7 @@
     <id>VirtoCommerce.Sitemaps</id>
     <version>3.8.0</version>
     <version-tag />
-    <platformVersion>3.81</platformVersion>
+    <platformVersion>3.81.0</platformVersion>
     <title>Sitemaps module</title>
     <description>Sitemaps generation management for stores</description>
     <authors>

--- a/tests/VirtoCommerce.SitemapsModule.Tests/VirtoCommerce.SitemapsModule.Tests.csproj
+++ b/tests/VirtoCommerce.SitemapsModule.Tests/VirtoCommerce.SitemapsModule.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.30.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.81.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>


### PR DESCRIPTION
## Description
Use assets from newly created module instead of the platform
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-4135
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Sitemaps_3.8.0-pr-39.zip
