### PR TITLE
Fix bug when content in the blogs folders are missed in the sitemap

### DIFF
--- a/src/VirtoCommerce.SitemapsModule.Data/Services/SitemapItemRecordProviders/StaticContentSitemapItemRecordProvider.cs
+++ b/src/VirtoCommerce.SitemapsModule.Data/Services/SitemapItemRecordProviders/StaticContentSitemapItemRecordProvider.cs
@@ -23,6 +23,7 @@ namespace VirtoCommerce.SitemapsModule.Data.Services.SitemapItemRecordProviders
     public class StaticContentSitemapItemRecordProvider : SitemapItemRecordProviderBase, ISitemapItemRecordProvider
     {
         private const string PagesContentType = "pages";
+        private const string BlogsContentType = "blogs";
         private static readonly Regex _headerRegExp = new Regex(@"(?s:^---(.*?)---)");
 
         private readonly ISettingsManager _settingsManager;
@@ -108,6 +109,12 @@ namespace VirtoCommerce.SitemapsModule.Data.Services.SitemapItemRecordProviders
             criteria.FolderUrl = folrderUrl;
 
             var searchResult = await _contentFileService.FilterItemsAsync(criteria);
+            //In case if we not find any content in the pages try to search in the blogs
+            if(!searchResult.Any())
+            {
+                criteria.ContentType = BlogsContentType;
+                searchResult = await _contentFileService.FilterItemsAsync(criteria);
+            }
 
             foreach (var file in searchResult.Where(file => file.Type == "blob" && IsExtensionAllowed(allowedExtensions, file.RelativeUrl)))
             {


### PR DESCRIPTION
## Description
How to reproduce:
- Add any not empty  blog folder ('news' as example) to the site map as content item
- Generate sitemap

Actual result:
- Resulting sitemap doesn't contains any links for blog pages in the folder "news"

Expected result:
- Resulting sitemap contains all links for blog pages  in the folder "news"

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Sitemaps_3.803.0-pr-70-e20f.zip
https://github.com/VirtoCommerce/vc-module-sitemaps/actions/runs/8341954445/job/22829091644
