### PR TITLE
VCST-2022: Bump YamIDotNet to the latest 16.1.3

### DIFF
--- a/src/VirtoCommerce.SitemapsModule.Data/VirtoCommerce.SitemapsModule.Data.csproj
+++ b/src/VirtoCommerce.SitemapsModule.Data/VirtoCommerce.SitemapsModule.Data.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.817.0" />
     <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.853.0" />
     <PackageReference Include="VirtoCommerce.Tools" Version="3.808.0" />
-    <PackageReference Include="YamlDotNet" Version="5.2.1" />
+    <PackageReference Include="YamlDotNet" Version="16.1.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.SitemapsModule.Core\VirtoCommerce.SitemapsModule.Core.csproj" />


### PR DESCRIPTION
## Description
feat: Bump YamIDotNet to the latest 16.1.3

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-2022
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Sitemaps_3.809.0-pr-76-5f02.zip