### PR TITLE
VCST-2752: Added option to specify SEO links type per sitemap and bugfix on cate…

### DIFF
--- a/src/VirtoCommerce.SitemapsModule.Core/Models/UrlTemplatePatterns.cs
+++ b/src/VirtoCommerce.SitemapsModule.Core/Models/UrlTemplatePatterns.cs
@@ -1,10 +1,13 @@
-﻿namespace VirtoCommerce.SitemapsModule.Core.Models
+namespace VirtoCommerce.SitemapsModule.Core.Models
 {
     public static class UrlTemplatePatterns
     {
         public const string StoreUrl = "{storeUrl}",
                             StoreSecureUrl = "{storeSecureUrl}",
                             Language = "{language}",
-                            Slug = "{slug}";
+                            Slug = "{slug}",
+                            SlugShort = "{slug_short}",
+                            SlugLong = "{slug_long}",
+                            SlugCollapsed = "{slug_collapsed}";
     }
 }

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/de.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/de.VirtoCommerce.Sitemaps.json
@@ -31,7 +31,8 @@
           "sitemapIndexErrorMessage": "Vermeiden Sie die Verwendung von \"sitemap.xml\" als Sitemap-Standort",
           "sitemapSitemapLocationExistErrorMessage": "Dieser Sitemap-Standort wird bereits verwendet",
           "labelSitemapItemsLocation": "Standort der Sitemap-Elemente",
-          "descriptionSitemapItemsLocation": "Definieren Sie das Muster zur Generierung von URLs für Sitemap-Elemente. Verwenden Sie {slug}, um den SEO-semantischen URL-Teil basierend auf den SEO-„Linkeinstellungen“ des Shops einzuschließen. Zum Beispiel: /meine-seite/{slug}",
+          "descriptionSitemapItemsLocation": "Definieren Sie das Muster zur Generierung von Sitemap-Element-URLs. Verwenden Sie {slug}, um den SEO-semantischen URL-Teil basierend auf den 'Links-Einstellungen' des Shops einzuschließen. Zum Beispiel: /meine-seite/{slug}.\n\nHier ist die vollständige Liste der unterstützten Slug-Formate:\n{slug} – URLs entsprechen der angegebenen 'SEO-Links'-Einstellung im Shop.\n{slug_short} – URLs entsprechen SeoLinksType.Short.\n{slug_long} – URLs entsprechen SeoLinksType.Long.\n{slug_collapsed}– URLs entsprechen SeoLinksType.Collapsed.",
+          "hide-description": "Verbergen",
           "labelSitemapItems": "Sitemap-Elemente",
           "sitemapMode": "Katalogelemente exportieren"
         },

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/en.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/en.VirtoCommerce.Sitemaps.json
@@ -31,9 +31,10 @@
           "sitemapIndexErrorMessage": "Avoid using \"sitemap.xml\" as the sitemap location",
           "sitemapSitemapLocationExistErrorMessage": "This sitemap location is already in use",
           "labelSitemapItemsLocation": "Sitemap items location",
-          "descriptionSitemapItemsLocation": "Define the pattern to generate sitemap item URLs.  Use {slug} to include the SEO semantic URL part based on the store's SEO 'Links Settings' rules. For example: /my-page/{slug}",
+          "descriptionSitemapItemsLocation": "Define the pattern to generate sitemap item URLs. Use {slug} to include the SEO semantic URL part based on the store's SEO 'Links Settings' rules. For example: /my-page/{slug}.\n\nHere is the complete list of supported slug formats:\n{slug} – URLs conform to the specified 'SEO links' setting on the store.\n{slug_short} – URLs conform to SeoLinksType.Short.\n{slug_long} – URLs conform to SeoLinksType.Long.\n{slug_collapsed} – URLs conform to SeoLinksType.Collapsed.",
           "labelSitemapItems": "Sitemap items",
-          "sitemapMode": "Export catalog items"
+          "sitemapMode": "Export catalog items",
+          "hide-description": "Hide"
         },
         "sitemapModes": {
           "sitemapFullMode": "Сategories and products",

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/es.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/es.VirtoCommerce.Sitemaps.json
@@ -31,7 +31,8 @@
           "sitemapIndexErrorMessage": "Evite usar \"sitemap.xml\" como ubicación del mapa del sitio",
           "sitemapSitemapLocationExistErrorMessage": "Esta ubicación del mapa del sitio ya está en uso",
           "labelSitemapItemsLocation": "Ubicación de los elementos del mapa del sitio",
-          "descriptionSitemapItemsLocation": "Defina el patrón para generar URLs de elementos del mapa del sitio. Use {slug} para incluir la parte semántica SEO de la URL basada en las reglas de 'Configuración de Enlaces' SEO de la tienda. Por ejemplo: /mi-pagina/{slug}",
+          "descriptionSitemapItemsLocation": "Defina el patrón para generar URLs de elementos del mapa del sitio. Use {slug} para incluir la parte semántica de la URL SEO basada en las reglas de 'Configuración de Enlaces' de la tienda. Por ejemplo: /mi-pagina/{slug}.\n\nAquí está la lista completa de formatos de slug soportados:\n{slug} – Las URLs se ajustan a la 'Configuración de Enlaces SEO' especificada en la tienda.\n{slug_short} – Las URLs se ajustan a SeoLinksType.Short.\n{slug_long} – Las URLs se ajustan a SeoLinksType.Long.\n{slug_collapsed} – Las URLs se ajustan a SeoLinksType.Collapsed.",
+          "hide-description": "Ocultar",
           "labelSitemapItems": "Elementos del mapa del sitio",
           "sitemapMode": "Exportar elementos del catálogo"
         },

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/fr.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/fr.VirtoCommerce.Sitemaps.json
@@ -31,7 +31,8 @@
           "sitemapIndexErrorMessage": "Évitez d'utiliser \"sitemap.xml\" comme emplacement du plan de site",
           "sitemapSitemapLocationExistErrorMessage": "Cet emplacement de plan de site est déjà utilisé",
           "labelSitemapItemsLocation": "Emplacement des éléments du plan de site",
-          "descriptionSitemapItemsLocation": "Définissez le modèle pour générer les URL des éléments du plan de site. Utilisez {slug} pour inclure la partie URL sémantique SEO basée sur les règles des 'Paramètres de liens' SEO du magasin. Par exemple : /ma-page/{slug}",
+          "descriptionSitemapItemsLocation": "Définissez le modèle pour générer les URL des éléments du plan de site. Utilisez {slug} pour inclure la partie URL sémantique SEO basée sur les règles 'Paramètres des liens' du magasin. Par exemple : /ma-page/{slug}.\n\nVoici la liste complète des formats de slug pris en charge :\n{slug} – Les URL sont conformes au paramètre 'Liens SEO' spécifié sur le magasin.\n{slug_short} – Les URL sont conformes à SeoLinksType.Short.\n{slug_long} – Les URL sont conformes à SeoLinksType.Long.\n{slug_collapsed} – Les URL sont conformes à SeoLinksType.Collapsed.",
+          "hide-description": "Cacher",
           "labelSitemapItems": "Éléments du plan de site",
           "sitemapMode": "Exporter les éléments du catalogue"
         },

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/it.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/it.VirtoCommerce.Sitemaps.json
@@ -31,7 +31,8 @@
           "sitemapIndexErrorMessage": "Evita di usare \"sitemap.xml\" come posizione della sitemap",
           "sitemapSitemapLocationExistErrorMessage": "Questa posizione della sitemap è già in uso",
           "labelSitemapItemsLocation": "Posizione degli elementi della sitemap",
-          "descriptionSitemapItemsLocation": "Definisci il modello per generare gli URL degli elementi della sitemap. Usa {slug} per includere la parte semantica SEO dell'URL basata sulle regole delle 'Impostazioni dei link' SEO del negozio. Ad esempio: /mia-pagina/{slug}",
+          "descriptionSitemapItemsLocation": "Definisci il modello per generare gli URL degli elementi della sitemap. Usa {slug} per includere la parte URL semantica SEO basata sulle regole 'Impostazioni Link' del negozio. Ad esempio: /mia-pagina/{slug}.\n\nEcco l'elenco completo dei formati slug supportati:\n{slug} – Gli URL sono conformi all'impostazione 'Link SEO' specificata nel negozio.\n{slug_short} – Gli URL sono conformi a SeoLinksType.Short.\n{slug_long} – Gli URL sono conformi a SeoLinksType.Long.\n{slug_collapsed} – Gli URL sono conformi a SeoLinksType.Collapsed.",
+          "hide-description": "Nascondi",
           "labelSitemapItems": "Elementi della sitemap",
           "sitemapMode": "Esporta elementi del catalogo"
         },

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/ja.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/ja.VirtoCommerce.Sitemaps.json
@@ -31,7 +31,8 @@
           "sitemapIndexErrorMessage": "\"sitemap.xml\" をサイトマップの場所として使用しないでください",
           "sitemapSitemapLocationExistErrorMessage": "このサイトマップの場所は既に使用されています",
           "labelSitemapItemsLocation": "サイトマップアイテムの場所",
-          "descriptionSitemapItemsLocation": "サイトマップアイテムのURLを生成するパターンを定義します。ストアのSEO「リンク設定」ルールに基づいて、SEOセマンティックURL部分を含めるには {slug} を使用します。例：/my-page/{slug}",
+          "descriptionSitemapItemsLocation": "サイトマップアイテムのURLを生成するパターンを定義します。{slug} を使用して、ストアのSEO「リンク設定」ルールに基づいたSEOセマンティックURL部分を含めます。例：/my-page/{slug}。\n\nサポートされているスラッグ形式の完全なリストは次のとおりです：\n{slug} – ストアで指定された「SEOリンク」設定に準拠したURL。\n{slug_short} – SeoLinksType.Shortに準拠したURL。\n{slug_long} – SeoLinksType.Longに準拠したURL。\n{slug_collapsed} – SeoLinksType.Collapsedに準拠したURL",
+          "hide-description": "非表示",
           "labelSitemapItems": "サイトマップアイテム",
           "sitemapMode": "カタログアイテムをエクスポート"
         },

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/pl.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/pl.VirtoCommerce.Sitemaps.json
@@ -31,7 +31,8 @@
           "sitemapIndexErrorMessage": "Unikaj używania \"sitemap.xml\" jako lokalizacji mapy witryny",
           "sitemapSitemapLocationExistErrorMessage": "Ta lokalizacja mapy witryny jest już używana",
           "labelSitemapItemsLocation": "Lokalizacja elementów mapy witryny",
-          "descriptionSitemapItemsLocation": "Zdefiniuj wzorzec generowania URL-i elementów mapy witryny. Użyj {slug}, aby uwzględnić semantyczną część URL SEO opartą na zasadach 'Ustawień linków' SEO sklepu. Na przykład: /moja-strona/{slug}",
+          "descriptionSitemapItemsLocation": "Zdefiniuj wzorzec generowania URL-i elementów mapy witryny. Użyj {slug}, aby uwzględnić semantyczną część URL SEO na podstawie zasad 'Ustawień linków' sklepu. Na przykład: /moja-strona/{slug}.\n\nOto pełna lista obsługiwanych formatów slug:\n{slug} – URL-e zgodne z określonym ustawieniem 'linków SEO' w sklepie.\n{slug_short} – URL-e zgodne z SeoLinksType.Short.\n{slug_long} – URL-e zgodne z SeoLinksType.Long.\n{slug_collapsed} – URL-e zgodne z SeoLinksType.Collapsed.",
+          "hide-description": "Ukryj",
           "labelSitemapItems": "Elementy mapy witryny",
           "sitemapMode": "Eksportuj elementy katalogu"
         },

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/pt.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/pt.VirtoCommerce.Sitemaps.json
@@ -31,7 +31,8 @@
           "sitemapIndexErrorMessage": "Evite usar \"sitemap.xml\" como localização do sitemap",
           "sitemapSitemapLocationExistErrorMessage": "Esta localização do sitemap já está em uso",
           "labelSitemapItemsLocation": "Localização dos itens do sitemap",
-          "descriptionSitemapItemsLocation": "Defina o padrão para gerar URLs de itens do sitemap. Use {slug} para incluir a parte semântica SEO da URL com base nas regras de 'Configurações de Links' SEO da loja. Por exemplo: /minha-pagina/{slug}",
+          "descriptionSitemapItemsLocation": "Defina o padrão para gerar URLs de itens do sitemap. Use {slug} para incluir a parte semântica da URL de SEO com base nas regras de 'Configurações de Links' da loja. Por exemplo: /minha-pagina/{slug}.\n\nAqui está a lista completa de formatos de slug suportados:\n{slug} – URLs conforme a configuração de 'links de SEO' especificada na loja.\n{slug_short} – URLs conforme SeoLinksType.Short.\n{slug_long} – URLs conforme SeoLinksType.Long.\n{slug_collapsed} – URLs conforme SeoLinksType.Collapsed.",
+          "hide-description": "Esconder",
           "labelSitemapItems": "Itens do sitemap",
           "sitemapMode": "Exportar itens do catálogo"
         },

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/ru.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/ru.VirtoCommerce.Sitemaps.json
@@ -31,7 +31,8 @@
           "sitemapIndexErrorMessage": "Избегайте использования \"sitemap.xml\" в качестве местоположения карты сайта",
           "sitemapSitemapLocationExistErrorMessage": "Это местоположение карты сайта уже используется",
           "labelSitemapItemsLocation": "Местоположение элементов карты сайта",
-          "descriptionSitemapItemsLocation": "Определите шаблон для генерации URL элементов карты сайта. Используйте {slug}, чтобы включить семантическую часть URL SEO на основе правил 'Настройки ссылок' SEO магазина. Например: /моя-страница/{slug}",
+          "descriptionSitemapItemsLocation": "Определите шаблон для генерации URL-адресов элементов карты сайта. Используйте {slug}, чтобы включить SEO-семантическую часть URL на основе правил 'Настройки ссылок' магазина. Например: /my-page/{slug}.\n\nВот полный список поддерживаемых форматов slug:\n{slug} – URL-адреса соответствуют указанной настройке 'SEO links' в магазине.\n{slug_short} – URL-адреса соответствуют SeoLinksType.Short.\n{slug_long} – URL-адреса соответствуют SeoLinksType.Long.\n{slug_collapsed} – URL-адреса соответствуют SeoLinksType.Collapsed.",  
+          "hide-description": "Скрыть",
           "labelSitemapItems": "Элементы карты сайта",
           "sitemapMode": "Экспортировать элементы каталога"
         },

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/zh.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/zh.VirtoCommerce.Sitemaps.json
@@ -31,7 +31,8 @@
           "sitemapIndexErrorMessage": "避免使用 \"sitemap.xml\" 作为网站地图位置",
           "sitemapSitemapLocationExistErrorMessage": "此网站地图位置已被使用",
           "labelSitemapItemsLocation": "网站地图项目位置",
-          "descriptionSitemapItemsLocation": "定义生成网站地图项目 URL 的模式。使用 {slug} 包含基于商店 SEO '链接设置' 规则的 SEO 语义 URL 部分。例如：/my-page/{slug}",
+          "descriptionSitemapItemsLocation": "定义生成网站地图项目 URL 的模式。使用 {slug} 包含基于商店 SEO '链接设置' 规则的 SEO 语义 URL 部分。例如：/my-page/{slug}。\n\n以下是支持的 slug 格式的完整列表：\n{slug} – URL 符合商店指定的 'SEO 链接' 设置。\n{slug_short} – URL 符合 SeoLinksType.Short。\n{slug_long} – URL 符合 SeoLinksType.Long。\n{slug_collapsed} – URL 符合 SeoLinksType.Collapsed",
+          "hide-description": "隐藏",
           "labelSitemapItems": "网站地图项目",
           "sitemapMode": "导出目录项目"
         },

--- a/src/VirtoCommerce.SitemapsModule.Web/Scripts/blades/sitemap-detail.tpl.html
+++ b/src/VirtoCommerce.SitemapsModule.Web/Scripts/blades/sitemap-detail.tpl.html
@@ -6,17 +6,25 @@
       <form class="list __info" name="formSitemap">
         <div class="form-group" ng-init="setForm(formSitemap)">
           <label class="form-label" for="sitemapPath" translate="sitemapsModule.blades.sitemap.formSitemap.labelSitemapLocation"></label>
+          <i class="form-ico fa fa-question-circle __link __lightblue" ng-click="blade.setting.labelSitemapLocation_descrVisible=!blade.setting.labelSitemapLocation_descrVisible"></i>
           <div class="form-input">
             <input id="sitemapPath" name="sitemapPath" required="required" type="text" ng-pattern="/^[a-z0-9_/\-.]+\.(xml)$/i" ng-model="blade.currentEntity.location" />
             <div class="error" ng-if="errorMessage">{{errorMessage | translate}}</div>
-            <div class="list-descr">{{'sitemapsModule.blades.sitemap.formSitemap.descriptionSitemapLocation' | translate}}</div>
+            <div ng-if="blade.setting.labelSitemapLocation_descrVisible">
+              <div class="list-descr">{{'sitemapsModule.blades.sitemap.formSitemap.descriptionSitemapLocation' | translate}}</div>
+              <a ng-click="blade.setting.labelSitemapLocation_descrVisible = null;">{{ 'sitemapsModule.blades.sitemap.formSitemap.hide-description' | translate }}</a>
+            </div>
           </div>
         </div>
         <div class="form-group">
           <label class="form-label" for="urlTemplate" ng-bind="'sitemapsModule.blades.sitemap.formSitemap.labelSitemapItemsLocation' | translate"></label>
+          <i class="form-ico fa fa-question-circle __link __lightblue" ng-click="blade.setting.labelSitemapItemsLocation_descrVisible=!blade.setting.labelSitemapItemsLocation_descrVisible"></i>
           <div class="form-input">
             <input id="urlTemplate" name="urlTemplate" required="required" type="text" ng-pattern="/^[a-z0-9_/\-.{}]+$/i" ng-model="blade.currentEntity.urlTemplate" />
-            <div class="list-descr" ng-bind="'sitemapsModule.blades.sitemap.formSitemap.descriptionSitemapItemsLocation' | translate"></div>
+            <div ng-if="blade.setting.labelSitemapItemsLocation_descrVisible">
+              <div style="white-space: pre-line;" class="list-descr" ng-bind="'sitemapsModule.blades.sitemap.formSitemap.descriptionSitemapItemsLocation' | translate"></div>
+              <a ng-click="blade.setting.labelSitemapItemsLocation_descrVisible = null;">{{ 'sitemapsModule.blades.sitemap.formSitemap.hide-description' | translate }}</a>
+            </div>
           </div>
         </div>
         <div class="form-group" ng-show="hasCatalogItems()">

--- a/src/VirtoCommerce.SitemapsModule.Web/package-lock.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/package-lock.json
@@ -531,10 +531,11 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1077,9 +1078,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true,
       "funding": [
         {
@@ -1087,6 +1088,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },


### PR DESCRIPTION
…gory url's in sitemap (#79)

## Description

1 | Added option to specify SEO links type per sitemap, allowing for example full path url's for categories and short urls's for products. 

This can be determined per sitemap via the 'Sitemaps items location' setting on the sitemap:
![image](https://github.com/user-attachments/assets/683262b6-2b73-430c-8016-96fbc794206e)

The following options are possible:
- {slug} -> Already existing option, url's are conform specified 'SEO links' setting on store
- {slug_short} -> Added option, url's are conform SeoLinksType.Short (overriding specified 'SEO links' setting on store for this sitemap)
- {slug_long} -> Added option, url's are conform SeoLinksType.Long (overriding specified 'SEO links' setting on store for this sitemap)
- {slug_collapsed} -> Added option, url's are conform SeoLinksType.Collapsed (overriding specified 'SEO links' setting on store for this sitemap)

2 | Fixed bug where categories where always short url, even if specified 'SEO links' setting on store was 'Long', due to missing 'IHasOutlines' on 'CategoryListEntry' in [vc-module-catalog](https://github.com/VirtoCommerce/vc-module-catalog)

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-2752
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Sitemaps_3.812.0-pr-81-4e92.zip