### PR TITLE
VCST-4768: the sitemap is generated for all files, regardless of how many files are selected.

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(dotnet build:*)",
+      "Bash(dotnet test:*)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(dotnet build:*)",
-      "Bash(dotnet test:*)"
-    ]
-  }
-}

--- a/src/VirtoCommerce.SitemapsModule.Data/BackgroundJobs/SitemapProcessJob.cs
+++ b/src/VirtoCommerce.SitemapsModule.Data/BackgroundJobs/SitemapProcessJob.cs
@@ -58,7 +58,7 @@ public class SitemapExportToAssetsJob
 
                 try
                 {
-                    await SaveSitemapToBlob(store.Id, store.Url, progressCallback: null);
+                    await SaveSitemapToBlob(store.Id, store.Url, sitemapIds: null, progressCallback: null);
                     _logger.LogInformation("Sitemap for store {storeId} exported successfully.", store.Id); // Log success
                 }
                 catch (Exception ex)
@@ -69,7 +69,7 @@ public class SitemapExportToAssetsJob
         }
     }
 
-    public Task BackgroundDownload(string storeId, string baseUrl, string localTmpFolder, SitemapDownloadNotification notification)
+    public Task BackgroundDownload(string storeId, string baseUrl, string localTmpFolder, string[] sitemapIds, SitemapDownloadNotification notification)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(storeId);
 
@@ -78,10 +78,10 @@ public class SitemapExportToAssetsJob
             throw new ArgumentException($"Incorrect base URL {baseUrl}");
         }
 
-        return InnerBackgroundDownload(storeId, baseUrl, localTmpFolder, notification);
+        return InnerBackgroundDownload(storeId, baseUrl, localTmpFolder, sitemapIds, notification);
     }
 
-    public Task BackgroundExportToAssets(string storeId, string baseUrl, SitemapExportToAssetNotification notification)
+    public Task BackgroundExportToAssets(string storeId, string baseUrl, string[] sitemapIds, SitemapExportToAssetNotification notification)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(storeId);
 
@@ -90,14 +90,14 @@ public class SitemapExportToAssetsJob
             throw new ArgumentException($"Incorrect base URL {baseUrl}");
         }
 
-        return InnerBackgroundExportToAssets(storeId, baseUrl, notification);
+        return InnerBackgroundExportToAssets(storeId, baseUrl, sitemapIds, notification);
     }
 
-    private async Task InnerBackgroundExportToAssets(string storeId, string baseUrl, SitemapExportToAssetNotification notification)
+    private async Task InnerBackgroundExportToAssets(string storeId, string baseUrl, string[] sitemapIds, SitemapExportToAssetNotification notification)
     {
         try
         {
-            var sitemapXmlBlobInfo = await SaveSitemapToBlob(storeId, baseUrl, progress => SendProgressNotification(notification, progress));
+            var sitemapXmlBlobInfo = await SaveSitemapToBlob(storeId, baseUrl, sitemapIds, progress => SendProgressNotification(notification, progress));
 
             notification.Description = "Sitemap export to store assets finished";
             notification.SitemapXmlUrl = sitemapXmlBlobInfo.Url;
@@ -114,7 +114,7 @@ public class SitemapExportToAssetsJob
         }
     }
 
-    private async Task InnerBackgroundDownload(string storeId, string baseUrl, string localTmpFolder, SitemapDownloadNotification notification)
+    private async Task InnerBackgroundDownload(string storeId, string baseUrl, string localTmpFolder, string[] sitemapIds, SitemapDownloadNotification notification)
     {
         var uniqueFileName = $"sitemap-{DateTime.UtcNow:yyyy-MM-dd}-{Guid.NewGuid()}.zip";
 
@@ -139,7 +139,7 @@ public class SitemapExportToAssetsJob
             await using (var stream = SystemFile.Open(localTmpPath, FileMode.CreateNew))
             using (var zipArchive = new ZipArchive(stream, ZipArchiveMode.Create, true))
             {
-                await SaveSitemapToZip(storeId, baseUrl, zipArchive, progress => SendProgressNotification(notification, progress));
+                await SaveSitemapToZip(storeId, baseUrl, sitemapIds, zipArchive, progress => SendProgressNotification(notification, progress));
             }
 
             //Copy data to blob provider to get public download URL
@@ -165,12 +165,12 @@ public class SitemapExportToAssetsJob
         }
     }
 
-    private async Task<BlobInfo> SaveSitemapToBlob(string storeId, string baseUrl, Action<ExportImportProgressInfo> progressCallback)
+    private async Task<BlobInfo> SaveSitemapToBlob(string storeId, string baseUrl, string[] sitemapIds, Action<ExportImportProgressInfo> progressCallback)
     {
         BlobInfo firstBlobInfo = null;
         var outputAssetFolder = string.Format(ModuleConstants.StoreAssetsOutputFolderTemplate, storeId);
 
-        var files = await _sitemapGenerator.GetSitemapFilesAsync(storeId, baseUrl, progressCallback);
+        var files = await _sitemapGenerator.GetSitemapFilesAsync(storeId, baseUrl, progressCallback, sitemapIds);
 
         foreach (var file in files)
         {
@@ -181,9 +181,9 @@ public class SitemapExportToAssetsJob
         return firstBlobInfo;
     }
 
-    private async Task SaveSitemapToZip(string storeId, string baseUrl, ZipArchive zipArchive, Action<ExportImportProgressInfo> progressCallback)
+    private async Task SaveSitemapToZip(string storeId, string baseUrl, string[] sitemapIds, ZipArchive zipArchive, Action<ExportImportProgressInfo> progressCallback)
     {
-        var files = await _sitemapGenerator.GetSitemapFilesAsync(storeId, baseUrl, progressCallback);
+        var files = await _sitemapGenerator.GetSitemapFilesAsync(storeId, baseUrl, progressCallback, sitemapIds);
 
         foreach (var file in files)
         {

--- a/src/VirtoCommerce.SitemapsModule.Data/Services/ISitemapGenerator.cs
+++ b/src/VirtoCommerce.SitemapsModule.Data/Services/ISitemapGenerator.cs
@@ -9,7 +9,7 @@ namespace VirtoCommerce.SitemapsModule.Data.Services;
 
 public interface ISitemapGenerator
 {
-    Task<IList<SitemapFile>> GetSitemapFilesAsync(string storeId, string baseUrl, Action<ExportImportProgressInfo> progressCallback = null);
+    Task<IList<SitemapFile>> GetSitemapFilesAsync(string storeId, string baseUrl, Action<ExportImportProgressInfo> progressCallback = null, string[] sitemapIds = null);
 
     void SaveSitemapFile(SitemapFile file, Stream stream, Action<ExportImportProgressInfo> progressCallback = null);
 }

--- a/src/VirtoCommerce.SitemapsModule.Data/Services/SitemapXmlGenerator.cs
+++ b/src/VirtoCommerce.SitemapsModule.Data/Services/SitemapXmlGenerator.cs
@@ -73,14 +73,14 @@ namespace VirtoCommerce.SitemapsModule.Data.Services
             return stream;
         }
 
-        public virtual async Task<IList<SitemapFile>> GetSitemapFilesAsync(string storeId, string baseUrl, Action<ExportImportProgressInfo> progressCallback = null)
+        public virtual async Task<IList<SitemapFile>> GetSitemapFilesAsync(string storeId, string baseUrl, Action<ExportImportProgressInfo> progressCallback = null, string[] sitemapIds = null)
         {
             var store = await _storeService.GetByIdAsync(storeId, nameof(StoreResponseGroup.StoreInfo));
 
-            return await GetSitemapFilesAsync(store, baseUrl, progressCallback);
+            return await GetSitemapFilesAsync(store, baseUrl, progressCallback, sitemapIds);
         }
 
-        public virtual async Task<IList<SitemapFile>> GetSitemapFilesAsync(Store store, string baseUrl, Action<ExportImportProgressInfo> progressCallback)
+        public virtual async Task<IList<SitemapFile>> GetSitemapFilesAsync(Store store, string baseUrl, Action<ExportImportProgressInfo> progressCallback, string[] sitemapIds = null)
         {
             var sitemapSearchCriteria = new SitemapSearchCriteria
             {
@@ -89,6 +89,11 @@ namespace VirtoCommerce.SitemapsModule.Data.Services
             };
 
             var sitemaps = (await _sitemapSearchService.SearchAsync(sitemapSearchCriteria)).Results;
+
+            if (sitemapIds?.Length > 0)
+            {
+                sitemaps = sitemaps.Where(s => sitemapIds.Contains(s.Id)).ToList();
+            }
             var files = new List<SitemapFile>();
 
             foreach (var sitemap in sitemaps)

--- a/src/VirtoCommerce.SitemapsModule.Web/Controllers/Api/SitemapsModuleApiController.cs
+++ b/src/VirtoCommerce.SitemapsModule.Web/Controllers/Api/SitemapsModuleApiController.cs
@@ -216,7 +216,7 @@ namespace VirtoCommerce.SitemapsModule.Web.Controllers.Api
 
         [HttpGet]
         [Route("download")]
-        public async Task<ActionResult<SitemapDownloadNotification>> DownloadSitemap(string storeId, string baseUrl)
+        public async Task<ActionResult<SitemapDownloadNotification>> DownloadSitemap(string storeId, string baseUrl, [FromQuery] string[] sitemapIds = null)
         {
             var notification = new SitemapDownloadNotification(_userNameResolver.GetCurrentUserName())
             {
@@ -228,7 +228,7 @@ namespace VirtoCommerce.SitemapsModule.Web.Controllers.Api
 
             var localTmpFolder = _hostingEnvironment.MapPath(Path.Combine("~/", _platformOptions.LocalUploadFolderPath, "tmp"));
 
-            BackgroundJob.Enqueue<SitemapExportToAssetsJob>(job => job.BackgroundDownload(storeId, baseUrl, localTmpFolder, notification));
+            BackgroundJob.Enqueue<SitemapExportToAssetsJob>(job => job.BackgroundDownload(storeId, baseUrl, localTmpFolder, sitemapIds, notification));
 
             return Ok(notification);
         }
@@ -236,7 +236,7 @@ namespace VirtoCommerce.SitemapsModule.Web.Controllers.Api
         [HttpGet]
         [Route("exportToStoreAssets")]
         [Authorize(ModuleConstants.Security.Permissions.ExportToStoreAssets)]
-        public async Task<ActionResult<SitemapDownloadNotification>> ExportToStoreAssets(string storeId, string baseUrl)
+        public async Task<ActionResult<SitemapDownloadNotification>> ExportToStoreAssets(string storeId, string baseUrl, [FromQuery] string[] sitemapIds = null)
         {
             var notification = new SitemapExportToAssetNotification(_userNameResolver.GetCurrentUserName())
             {
@@ -246,7 +246,7 @@ namespace VirtoCommerce.SitemapsModule.Web.Controllers.Api
 
             await _notifier.SendAsync(notification);
 
-            BackgroundJob.Enqueue<SitemapExportToAssetsJob>(job => job.BackgroundExportToAssets(storeId, baseUrl, notification));
+            BackgroundJob.Enqueue<SitemapExportToAssetsJob>(job => job.BackgroundExportToAssets(storeId, baseUrl, sitemapIds, notification));
 
             return Ok(notification);
         }

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/de.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/de.VirtoCommerce.Sitemaps.json
@@ -138,7 +138,11 @@
       "confirmBaseUrl": {
         "title": "Basis-URL",
         "messageNoBaseUrl": "Geben Sie die Basis-URL für Sitemaps ein",
-        "messageConfirmBaseUrl": "Bestätigen Sie die Basis-URL für Sitemaps"
+        "messageConfirmBaseUrl": "Bestätigen Sie die Basis-URL für Sitemaps",
+        "messageExportAll": "Alle Sitemaps werden exportiert. Bestätigen Sie die Basis-URL für Sitemaps.",
+        "messageExportSelected": "{{count}} ausgewählte Sitemap(s) werden exportiert. Bestätigen Sie die Basis-URL für Sitemaps.",
+        "messageDownloadAll": "Alle Sitemaps werden als ZIP heruntergeladen. Bestätigen Sie die Basis-URL für Sitemaps.",
+        "messageDownloadSelected": "{{count}} ausgewählte Sitemap(s) werden als ZIP heruntergeladen. Bestätigen Sie die Basis-URL für Sitemaps."
       },
       "discardChanges": {
         "title": "Änderungen speichern",

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/en.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/en.VirtoCommerce.Sitemaps.json
@@ -138,7 +138,11 @@
       "confirmBaseUrl": {
         "title": "Base URL",
         "messageNoBaseUrl": "Enter base URL for sitemaps",
-        "messageConfirmBaseUrl": "Confirm base URL for sitemaps"
+        "messageConfirmBaseUrl": "Confirm base URL for sitemaps",
+        "messageExportAll": "All sitemaps will be exported. Confirm base URL for sitemaps.",
+        "messageExportSelected": "{{count}} selected sitemap(s) will be exported. Confirm base URL for sitemaps.",
+        "messageDownloadAll": "All sitemaps will be downloaded as ZIP. Confirm base URL for sitemaps.",
+        "messageDownloadSelected": "{{count}} selected sitemap(s) will be downloaded as ZIP. Confirm base URL for sitemaps."
       },
       "discardChanges": {
         "title": "Save changes",

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/es.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/es.VirtoCommerce.Sitemaps.json
@@ -138,7 +138,11 @@
       "confirmBaseUrl": {
         "title": "URL base",
         "messageNoBaseUrl": "Ingrese la URL base para los mapas del sitio",
-        "messageConfirmBaseUrl": "Confirme la URL base para los mapas del sitio"
+        "messageConfirmBaseUrl": "Confirme la URL base para los mapas del sitio",
+        "messageExportAll": "Se exportarán todos los mapas del sitio. Confirme la URL base para los mapas del sitio.",
+        "messageExportSelected": "Se exportarán {{count}} mapa(s) del sitio seleccionado(s). Confirme la URL base para los mapas del sitio.",
+        "messageDownloadAll": "Todos los mapas del sitio se descargarán como ZIP. Confirme la URL base para los mapas del sitio.",
+        "messageDownloadSelected": "{{count}} mapa(s) del sitio seleccionado(s) se descargarán como ZIP. Confirme la URL base para los mapas del sitio."
       },
       "discardChanges": {
         "title": "Guardar cambios",

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/fi.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/fi.VirtoCommerce.Sitemaps.json
@@ -138,7 +138,11 @@
       "confirmBaseUrl": {
         "title": "Perus-URL",
         "messageNoBaseUrl": "Anna sivukarttojen perus-URL",
-        "messageConfirmBaseUrl": "Vahvista sivukarttojen perus-URL"
+        "messageConfirmBaseUrl": "Vahvista sivukarttojen perus-URL",
+        "messageExportAll": "Kaikki sivukartat viedään. Vahvista sivukarttojen perus-URL.",
+        "messageExportSelected": "{{count}} valittua sivukarttaa viedään. Vahvista sivukarttojen perus-URL.",
+        "messageDownloadAll": "Kaikki sivukartat ladataan ZIP-tiedostona. Vahvista sivukarttojen perus-URL.",
+        "messageDownloadSelected": "{{count}} valittua sivukarttaa ladataan ZIP-tiedostona. Vahvista sivukarttojen perus-URL."
       },
       "discardChanges": {
         "title": "Tallenna muutokset",

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/fr.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/fr.VirtoCommerce.Sitemaps.json
@@ -138,7 +138,11 @@
       "confirmBaseUrl": {
         "title": "URL de base",
         "messageNoBaseUrl": "Entrez l'URL de base pour les plans de site",
-        "messageConfirmBaseUrl": "Confirmez l'URL de base pour les plans de site"
+        "messageConfirmBaseUrl": "Confirmez l'URL de base pour les plans de site",
+        "messageExportAll": "Tous les plans de site seront exportés. Confirmez l'URL de base pour les plans de site.",
+        "messageExportSelected": "{{count}} plan(s) de site sélectionné(s) seront exportés. Confirmez l'URL de base pour les plans de site.",
+        "messageDownloadAll": "Tous les plans de site seront téléchargés en ZIP. Confirmez l'URL de base pour les plans de site.",
+        "messageDownloadSelected": "{{count}} plan(s) de site sélectionné(s) seront téléchargés en ZIP. Confirmez l'URL de base pour les plans de site."
       },
       "discardChanges": {
         "title": "Enregistrer les modifications",

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/it.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/it.VirtoCommerce.Sitemaps.json
@@ -138,7 +138,11 @@
       "confirmBaseUrl": {
         "title": "URL di base",
         "messageNoBaseUrl": "Inserisci l'URL di base per le sitemap",
-        "messageConfirmBaseUrl": "Conferma l'URL di base per le sitemap"
+        "messageConfirmBaseUrl": "Conferma l'URL di base per le sitemap",
+        "messageExportAll": "Tutte le sitemap verranno esportate. Conferma l'URL di base per le sitemap.",
+        "messageExportSelected": "{{count}} sitemap selezionate verranno esportate. Conferma l'URL di base per le sitemap.",
+        "messageDownloadAll": "Tutte le sitemap verranno scaricate come ZIP. Conferma l'URL di base per le sitemap.",
+        "messageDownloadSelected": "{{count}} sitemap selezionate verranno scaricate come ZIP. Conferma l'URL di base per le sitemap."
       },
       "discardChanges": {
         "title": "Salva modifiche",

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/ja.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/ja.VirtoCommerce.Sitemaps.json
@@ -138,7 +138,11 @@
       "confirmBaseUrl": {
         "title": "基本URL",
         "messageNoBaseUrl": "サイトマップの基本URLを入力してください",
-        "messageConfirmBaseUrl": "サイトマップの基本URLを確認してください"
+        "messageConfirmBaseUrl": "サイトマップの基本URLを確認してください",
+        "messageExportAll": "すべてのサイトマップがエクスポートされます。サイトマップの基本URLを確認してください。",
+        "messageExportSelected": "{{count}}件の選択されたサイトマップがエクスポートされます。サイトマップの基本URLを確認してください。",
+        "messageDownloadAll": "すべてのサイトマップがZIPとしてダウンロードされます。サイトマップの基本URLを確認してください。",
+        "messageDownloadSelected": "{{count}}件の選択されたサイトマップがZIPとしてダウンロードされます。サイトマップの基本URLを確認してください。"
       },
       "discardChanges": {
         "title": "変更を保存",

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/no.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/no.VirtoCommerce.Sitemaps.json
@@ -138,7 +138,11 @@
       "confirmBaseUrl": {
         "title": "Base-URL",
         "messageNoBaseUrl": "Angi base-URL for nettstedskart",
-        "messageConfirmBaseUrl": "Bekreft base-URL for nettstedskart"
+        "messageConfirmBaseUrl": "Bekreft base-URL for nettstedskart",
+        "messageExportAll": "Alle nettstedskart vil bli eksportert. Bekreft base-URL for nettstedskart.",
+        "messageExportSelected": "{{count}} valgte nettstedskart vil bli eksportert. Bekreft base-URL for nettstedskart.",
+        "messageDownloadAll": "Alle nettstedskart vil bli lastet ned som ZIP. Bekreft base-URL for nettstedskart.",
+        "messageDownloadSelected": "{{count}} valgte nettstedskart vil bli lastet ned som ZIP. Bekreft base-URL for nettstedskart."
       },
       "discardChanges": {
         "title": "Lagre endringer",

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/pl.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/pl.VirtoCommerce.Sitemaps.json
@@ -138,7 +138,11 @@
       "confirmBaseUrl": {
         "title": "Podstawowy URL",
         "messageNoBaseUrl": "Wprowadź podstawowy URL dla map witryn",
-        "messageConfirmBaseUrl": "Potwierdź podstawowy URL dla map witryn"
+        "messageConfirmBaseUrl": "Potwierdź podstawowy URL dla map witryn",
+        "messageExportAll": "Wszystkie mapy witryn zostaną wyeksportowane. Potwierdź podstawowy URL dla map witryn.",
+        "messageExportSelected": "{{count}} wybranych map witryn zostanie wyeksportowanych. Potwierdź podstawowy URL dla map witryn.",
+        "messageDownloadAll": "Wszystkie mapy witryn zostaną pobrane jako ZIP. Potwierdź podstawowy URL dla map witryn.",
+        "messageDownloadSelected": "{{count}} wybranych map witryn zostanie pobranych jako ZIP. Potwierdź podstawowy URL dla map witryn."
       },
       "discardChanges": {
         "title": "Zapisz zmiany",

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/pt.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/pt.VirtoCommerce.Sitemaps.json
@@ -138,7 +138,11 @@
       "confirmBaseUrl": {
         "title": "URL base",
         "messageNoBaseUrl": "Insira a URL base para os sitemaps",
-        "messageConfirmBaseUrl": "Confirme a URL base para os sitemaps"
+        "messageConfirmBaseUrl": "Confirme a URL base para os sitemaps",
+        "messageExportAll": "Todos os sitemaps serão exportados. Confirme a URL base para os sitemaps.",
+        "messageExportSelected": "{{count}} sitemap(s) selecionado(s) serão exportados. Confirme a URL base para os sitemaps.",
+        "messageDownloadAll": "Todos os sitemaps serão baixados como ZIP. Confirme a URL base para os sitemaps.",
+        "messageDownloadSelected": "{{count}} sitemap(s) selecionado(s) serão baixados como ZIP. Confirme a URL base para os sitemaps."
       },
       "discardChanges": {
         "title": "Salvar alterações",

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/ru.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/ru.VirtoCommerce.Sitemaps.json
@@ -138,7 +138,11 @@
       "confirmBaseUrl": {
         "title": "Базовый URL",
         "messageNoBaseUrl": "Введите базовый URL для карт сайта",
-        "messageConfirmBaseUrl": "Подтвердите базовый URL для карт сайта"
+        "messageConfirmBaseUrl": "Подтвердите базовый URL для карт сайта",
+        "messageExportAll": "Все карты сайта будут экспортированы. Подтвердите базовый URL для карт сайта.",
+        "messageExportSelected": "Будет экспортировано {{count}} выбранных карт(а) сайта. Подтвердите базовый URL для карт сайта.",
+        "messageDownloadAll": "Все карты сайта будут скачаны в формате ZIP. Подтвердите базовый URL для карт сайта.",
+        "messageDownloadSelected": "{{count}} выбранных карт(а) сайта будут скачаны в формате ZIP. Подтвердите базовый URL для карт сайта."
       },
       "discardChanges": {
         "title": "Сохранить изменения",

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/sv.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/sv.VirtoCommerce.Sitemaps.json
@@ -138,7 +138,11 @@
       "confirmBaseUrl": {
         "title": "Bas-URL",
         "messageNoBaseUrl": "Ange bas-URL för sajtkartor",
-        "messageConfirmBaseUrl": "Bekräfta bas-URL för sajtkartor"
+        "messageConfirmBaseUrl": "Bekräfta bas-URL för sajtkartor",
+        "messageExportAll": "Alla sajtkartor kommer att exporteras. Bekräfta bas-URL för sajtkartor.",
+        "messageExportSelected": "{{count}} valda sajtkarta/sajtkartor kommer att exporteras. Bekräfta bas-URL för sajtkartor.",
+        "messageDownloadAll": "Alla sajtkartor kommer att laddas ner som ZIP. Bekräfta bas-URL för sajtkartor.",
+        "messageDownloadSelected": "{{count}} valda sajtkarta/sajtkartor kommer att laddas ner som ZIP. Bekräfta bas-URL för sajtkartor."
       },
       "discardChanges": {
         "title": "Spara ändringar",

--- a/src/VirtoCommerce.SitemapsModule.Web/Localizations/zh.VirtoCommerce.Sitemaps.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/Localizations/zh.VirtoCommerce.Sitemaps.json
@@ -138,7 +138,11 @@
       "confirmBaseUrl": {
         "title": "基本 URL",
         "messageNoBaseUrl": "输入网站地图的基本 URL",
-        "messageConfirmBaseUrl": "确认网站地图的基本 URL"
+        "messageConfirmBaseUrl": "确认网站地图的基本 URL",
+        "messageExportAll": "将导出所有网站地图。请确认网站地图的基本 URL。",
+        "messageExportSelected": "将导出 {{count}} 个选定的网站地图。请确认网站地图的基本 URL。",
+        "messageDownloadAll": "将以 ZIP 格式下载所有网站地图。请确认网站地图的基本 URL。",
+        "messageDownloadSelected": "将以 ZIP 格式下载 {{count}} 个选定的网站地图。请确认网站地图的基本 URL。"
       },
       "discardChanges": {
         "title": "保存更改",

--- a/src/VirtoCommerce.SitemapsModule.Web/Scripts/blades/sitemap-download.js
+++ b/src/VirtoCommerce.SitemapsModule.Web/Scripts/blades/sitemap-download.js
@@ -11,7 +11,8 @@
 
     sitemapApi.download({
         storeId: blade.storeId,
-        baseUrl: blade.baseUrl
+        baseUrl: blade.baseUrl,
+        sitemapIds: blade.sitemapIds
     },
     function (response) {
         blade.notification = response;

--- a/src/VirtoCommerce.SitemapsModule.Web/Scripts/blades/sitemap-export-to-assets.js
+++ b/src/VirtoCommerce.SitemapsModule.Web/Scripts/blades/sitemap-export-to-assets.js
@@ -11,7 +11,8 @@ angular.module('virtoCommerce.sitemapsModule')
 
         sitemapApi.exportToStoreAssets({
             storeId: blade.storeId,
-            baseUrl: blade.baseUrl
+            baseUrl: blade.baseUrl,
+            sitemapIds: blade.sitemapIds
         },
             function (response) {
                 blade.notification = response;

--- a/src/VirtoCommerce.SitemapsModule.Web/Scripts/blades/sitemap-list.js
+++ b/src/VirtoCommerce.SitemapsModule.Web/Scripts/blades/sitemap-list.js
@@ -94,11 +94,15 @@ angular.module('virtoCommerce.sitemapsModule').controller('virtoCommerce.sitemap
     }
 
     function showExportToStoreAssetsDialog() {
+        var selectedRows = $scope.gridApi ? $scope.gridApi.selection.getSelectedRows() : [];
+        var sitemapIds = selectedRows.length > 0 ? _.pluck(selectedRows, 'id') : undefined;
         var baseUrl = blade.store.url || blade.store.secureUrl
         var confirmDialog = {
             id: 'confirmBaseUrl',
             originalBaseUrl: angular.copy(baseUrl),
             baseUrl: baseUrl,
+            actionType: 'export',
+            selectedCount: selectedRows.length,
             templateUrl: 'Modules/$(VirtoCommerce.Sitemaps)/Scripts/dialogs/confirm-base-url-dialog.tpl.html',
             controller: 'virtoCommerce.sitemapsModule.baseUrlDialogController',
             resolve: {
@@ -117,7 +121,8 @@ angular.module('virtoCommerce.sitemapsModule').controller('virtoCommerce.sitemap
                     controller: 'virtoCommerce.sitemapsModule.sitemapExportToStoreAssetsController',
                     template: 'Modules/$(VirtoCommerce.Sitemaps)/Scripts/blades/sitemap-export-to-assets.tpl.html',
                     storeId: blade.store.id,
-                    baseUrl: baseUrl
+                    baseUrl: baseUrl,
+                    sitemapIds: sitemapIds
                 };
                 bladeNavigationService.showBlade(newBlade, blade);
             }
@@ -125,11 +130,15 @@ angular.module('virtoCommerce.sitemapsModule').controller('virtoCommerce.sitemap
     }
 
     function showDownloadDialog() {
+        var selectedRows = $scope.gridApi ? $scope.gridApi.selection.getSelectedRows() : [];
+        var sitemapIds = selectedRows.length > 0 ? _.pluck(selectedRows, 'id') : undefined;
         var baseUrl = blade.store.url || blade.store.secureUrl
         var confirmDialog = {
             id: 'confirmBaseUrl',
             originalBaseUrl: angular.copy(baseUrl),
             baseUrl: baseUrl,
+            actionType: 'download',
+            selectedCount: selectedRows.length,
             templateUrl: 'Modules/$(VirtoCommerce.Sitemaps)/Scripts/dialogs/confirm-base-url-dialog.tpl.html',
             controller: 'virtoCommerce.sitemapsModule.baseUrlDialogController',
             resolve: {
@@ -148,7 +157,8 @@ angular.module('virtoCommerce.sitemapsModule').controller('virtoCommerce.sitemap
                     controller: 'virtoCommerce.sitemapsModule.sitemapDownloadController',
                     template: 'Modules/$(VirtoCommerce.Sitemaps)/Scripts/blades/sitemap-download.tpl.html',
                     storeId: blade.store.id,
-                    baseUrl: baseUrl
+                    baseUrl: baseUrl,
+                    sitemapIds: sitemapIds
                 };
                 bladeNavigationService.showBlade(newBlade, blade);
             }

--- a/src/VirtoCommerce.SitemapsModule.Web/Scripts/dialogs/confirm-base-url-dialog.tpl.html
+++ b/src/VirtoCommerce.SitemapsModule.Web/Scripts/dialogs/confirm-base-url-dialog.tpl.html
@@ -1,10 +1,14 @@
-﻿<form id="formBaseUrl" name="formBaseUrl">
+<form id="formBaseUrl" name="formBaseUrl">
     <div class="modal-header">
         <h3 class="modal-title" ng-bind="'sitemapsModule.dialogs.confirmBaseUrl.title' | translate"></h3>
     </div>
     <div class="modal-body">
-        <p ng-if="!originalBaseUrl" ng-bind="'sitemapsModule.dialogs.confirmBaseUrl.messageNoBaseUrl' | translate"></p>
-        <p ng-if="originalBaseUrl" ng-bind="'sitemapsModule.dialogs.confirmBaseUrl.messageConfirmBaseUrl' | translate"></p>
+        <p ng-if="actionType === 'export' && !selectedCount" ng-bind="'sitemapsModule.dialogs.confirmBaseUrl.messageExportAll' | translate"></p>
+        <p ng-if="actionType === 'export' && selectedCount" ng-bind="'sitemapsModule.dialogs.confirmBaseUrl.messageExportSelected' | translate:{count: selectedCount}"></p>
+        <p ng-if="actionType === 'download' && !selectedCount" ng-bind="'sitemapsModule.dialogs.confirmBaseUrl.messageDownloadAll' | translate"></p>
+        <p ng-if="actionType === 'download' && selectedCount" ng-bind="'sitemapsModule.dialogs.confirmBaseUrl.messageDownloadSelected' | translate:{count: selectedCount}"></p>
+        <p ng-if="!actionType && !originalBaseUrl" ng-bind="'sitemapsModule.dialogs.confirmBaseUrl.messageNoBaseUrl' | translate"></p>
+        <p ng-if="!actionType && originalBaseUrl" ng-bind="'sitemapsModule.dialogs.confirmBaseUrl.messageConfirmBaseUrl' | translate"></p>
         <div class="form-group">
             <div class="form-input">
                 <input id="baseUrl" name="baseUrl" required="required" type="url" ng-model="baseUrl" />

--- a/src/VirtoCommerce.SitemapsModule.Web/package-lock.json
+++ b/src/VirtoCommerce.SitemapsModule.Web/package-lock.json
@@ -380,15 +380,16 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -853,6 +854,23 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -1313,10 +1331,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1714,25 +1733,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
-    "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rechoir": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
@@ -1814,27 +1814,6 @@
         "rimraf": "bin.js"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/schema-utils": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
@@ -1866,16 +1845,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/shallow-clone": {
@@ -2001,16 +1970,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {
@@ -2070,15 +2038,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/tests/VirtoCommerce.SitemapsModule.Tests/VirtoCommerce.SitemapsModule.Tests.csproj
+++ b/tests/VirtoCommerce.SitemapsModule.Tests/VirtoCommerce.SitemapsModule.Tests.csproj
@@ -17,7 +17,7 @@
     <EmbeddedResource Include="Resources\sitemap_short_en_de.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Description
fix: Fix resolves issue when the sitemap was generated for all files, regardless of how many files are selected.

<img width="746" height="546" alt="image" src="https://github.com/user-attachments/assets/d1c048c8-09e7-479a-b970-a229ee4de59b" />


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4786
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Sitemaps_3.1001.0-pr-90-b540.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the sitemap generation/export pipeline end-to-end (UI → API → Hangfire job → generator), so mistakes could cause exporting the wrong set of sitemap files or break existing integrations expecting the old job/API signatures.
> 
> **Overview**
> Fixes sitemap export/download always including *all* sitemaps by threading optional `sitemapIds` from the UI selection through the `api/sitemaps/download` and `api/sitemaps/exportToStoreAssets` endpoints into the Hangfire job and `ISitemapGenerator.GetSitemapFilesAsync`.
> 
> `SitemapXmlGenerator` now filters the sitemap search results when `sitemapIds` are provided, and the UI confirmation dialog messaging is updated (all vs selected counts) across localizations.
> 
> Also bumps a few dev/test dependencies (`ajv`, `minimatch`, `terser-webpack-plugin`, `coverlet.collector`) via `package-lock.json` and the test project.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b54016e1d83a375efe4f27ff3c67037982b8e047. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->