### PR TITLE
VCST-5163: Stable 15 — Sitemaps (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.SitemapsModule.Core/VirtoCommerce.SitemapsModule.Core.csproj
+++ b/src/VirtoCommerce.SitemapsModule.Core/VirtoCommerce.SitemapsModule.Core.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1007.10" />
-    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1029.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1005.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.SitemapsModule.Data.MySql/VirtoCommerce.SitemapsModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.SitemapsModule.Data.MySql/VirtoCommerce.SitemapsModule.Data.MySql.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.SitemapsModule.Data\VirtoCommerce.SitemapsModule.Data.csproj" />

--- a/src/VirtoCommerce.SitemapsModule.Data.PostgreSql/VirtoCommerce.SitemapsModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.SitemapsModule.Data.PostgreSql/VirtoCommerce.SitemapsModule.Data.PostgreSql.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.SitemapsModule.Data\VirtoCommerce.SitemapsModule.Data.csproj" />

--- a/src/VirtoCommerce.SitemapsModule.Data.SqlServer/VirtoCommerce.SitemapsModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.SitemapsModule.Data.SqlServer/VirtoCommerce.SitemapsModule.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.SitemapsModule.Data\VirtoCommerce.SitemapsModule.Data.csproj" />

--- a/src/VirtoCommerce.SitemapsModule.Data/ExportImport/SitemapExportImport.cs
+++ b/src/VirtoCommerce.SitemapsModule.Data/ExportImport/SitemapExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -29,7 +30,7 @@ namespace VirtoCommerce.SitemapsModule.Data.ExportImport
             _jsonSerializer = jsonSerializer;
         }
 
-        public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -67,7 +68,7 @@ namespace VirtoCommerce.SitemapsModule.Data.ExportImport
             }
         }
 
-        public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/VirtoCommerce.SitemapsModule.Data/ExportImport/SitemapExportImport.cs
+++ b/src/VirtoCommerce.SitemapsModule.Data/ExportImport/SitemapExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+
 using System.Threading;
 using System.IO;
 using System.Linq;
@@ -40,12 +41,12 @@ namespace VirtoCommerce.SitemapsModule.Data.ExportImport
             using (var sw = new StreamWriter(outStream))
             using (var writer = new JsonTextWriter(sw))
             {
-                await writer.WriteStartObjectAsync();
+                await writer.WriteStartObjectAsync(cancellationToken);
 
                 progressInfo.Description = "Site maps exporting...";
                 progressCallback(progressInfo);
 
-                await writer.WritePropertyNameAsync("Sitemaps");
+                await writer.WritePropertyNameAsync("Sitemaps", cancellationToken);
 
                 await writer.SerializeArrayWithPagingAsync(_jsonSerializer, _batchSize, async (skip, take) => (GenericSearchResult<Sitemap>)await _sitemapSearchService.SearchAsync(new SitemapSearchCriteria { Skip = skip, Take = take }), (processedCount, totalCount) =>
                 {
@@ -56,15 +57,15 @@ namespace VirtoCommerce.SitemapsModule.Data.ExportImport
                 progressInfo.Description = "Site map items exporting...";
                 progressCallback(progressInfo);
 
-                await writer.WritePropertyNameAsync("SitemapItems");
+                await writer.WritePropertyNameAsync("SitemapItems", cancellationToken);
                 await writer.SerializeArrayWithPagingAsync(_jsonSerializer, _batchSize, async (skip, take) => (GenericSearchResult<SitemapItem>)await _sitemapItemSearchService.SearchAsync(new SitemapItemSearchCriteria { Skip = skip, Take = take }), (processedCount, totalCount) =>
                 {
                     progressInfo.Description = $"{processedCount} of {totalCount} site maps items have been exported";
                     progressCallback(progressInfo);
                 }, cancellationToken);
 
-                await writer.WriteEndObjectAsync();
-                await writer.FlushAsync();
+                await writer.WriteEndObjectAsync(cancellationToken);
+                await writer.FlushAsync(cancellationToken);
             }
         }
 
@@ -77,7 +78,7 @@ namespace VirtoCommerce.SitemapsModule.Data.ExportImport
             using (var streamReader = new StreamReader(inputStream))
             using (var reader = new JsonTextReader(streamReader))
             {
-                while (await reader.ReadAsync())
+                while (await reader.ReadAsync(cancellationToken))
                 {
                     if (reader.TokenType == JsonToken.PropertyName)
                     {

--- a/src/VirtoCommerce.SitemapsModule.Data/VirtoCommerce.SitemapsModule.Data.csproj
+++ b/src/VirtoCommerce.SitemapsModule.Data/VirtoCommerce.SitemapsModule.Data.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.ContentModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1007.10" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1005.0" />
+    <PackageReference Include="VirtoCommerce.ContentModule.Core" Version="3.1003.0" />
+    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1010.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/VirtoCommerce.SitemapsModule.Web/Module.cs
+++ b/src/VirtoCommerce.SitemapsModule.Web/Module.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.IO;
 using System.Threading.Tasks;
 using Hangfire;
@@ -114,14 +115,14 @@ namespace VirtoCommerce.SitemapsModule.Web
         }
 
         public Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback,
-            ICancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
             return _appBuilder.ApplicationServices.GetRequiredService<SitemapExportImport>().DoExportAsync(outStream,
                 progressCallback, cancellationToken);
         }
 
         public Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback,
-            ICancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
             return _appBuilder.ApplicationServices.GetRequiredService<SitemapExportImport>().DoImportAsync(inputStream,
                 progressCallback, cancellationToken);

--- a/src/VirtoCommerce.SitemapsModule.Web/module.manifest
+++ b/src/VirtoCommerce.SitemapsModule.Web/module.manifest
@@ -4,14 +4,14 @@
   <version>3.1003.0</version>
   <version-tag />
 
-  <platformVersion>3.1007.10</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Catalog" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Content" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Core" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Customer" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Store" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
+    <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
+    <dependency id="VirtoCommerce.Content" version="3.1003.0" />
+    <dependency id="VirtoCommerce.Core" version="3.1007.0" />
+    <dependency id="VirtoCommerce.Customer" version="3.1010.0" />
+    <dependency id="VirtoCommerce.Store" version="3.1005.0" />
   </dependencies>
 
   <title>Sitemap Generator</title>

--- a/tests/VirtoCommerce.SitemapsModule.Tests/SitemapExportImportTests.cs
+++ b/tests/VirtoCommerce.SitemapsModule.Tests/SitemapExportImportTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -229,7 +230,7 @@ namespace VirtoCommerce.SitemapsModule.Tests
         private readonly Mock<ISitemapItemService> _sitemapItemService;
         private readonly Mock<ISitemapSearchService> _sitemapSearchService;
         private readonly Mock<ISitemapItemSearchService> _sitemapItemSearchService;
-        private readonly Mock<ICancellationToken> _cancellationToken;
+        private readonly CancellationToken _cancellationToken;
         private readonly SitemapExportImport _sitemapExportImport;
 
         public SitemapExportImportTests()
@@ -238,7 +239,7 @@ namespace VirtoCommerce.SitemapsModule.Tests
             _sitemapItemService = new Mock<ISitemapItemService>();
             _sitemapSearchService = new Mock<ISitemapSearchService>();
             _sitemapItemSearchService = new Mock<ISitemapItemSearchService>();
-            _cancellationToken = new Mock<ICancellationToken>();
+            _cancellationToken = CancellationToken.None;
 
             InitSitemapService();
             InitSitemapItemService();
@@ -281,7 +282,7 @@ namespace VirtoCommerce.SitemapsModule.Tests
             string actualJson;
             using (var targetStream = new MemoryStream())
             {
-                await _sitemapExportImport.DoExportAsync(targetStream, IgnoreProgressInfo, _cancellationToken.Object);
+                await _sitemapExportImport.DoExportAsync(targetStream, IgnoreProgressInfo, _cancellationToken);
 
                 var targetStreamContents = targetStream.ToArray();
                 using (var copiedStream = new MemoryStream(targetStreamContents))
@@ -315,7 +316,7 @@ namespace VirtoCommerce.SitemapsModule.Tests
             // Act
             using (var resourceStream = ReadEmbeddedResource("Resources.SerializedSitemapsData.json"))
             {
-                await _sitemapExportImport.DoImportAsync(resourceStream, IgnoreProgressInfo, _cancellationToken.Object);
+                await _sitemapExportImport.DoImportAsync(resourceStream, IgnoreProgressInfo, _cancellationToken);
             }
 
             // Assert

--- a/tests/VirtoCommerce.SitemapsModule.Tests/VirtoCommerce.SitemapsModule.Tests.csproj
+++ b/tests/VirtoCommerce.SitemapsModule.Tests/VirtoCommerce.SitemapsModule.Tests.csproj
@@ -17,7 +17,7 @@
     <EmbeddedResource Include="Resources\sitemap_short_en_de.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Part of **Stable 15** (Wave 5). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave 1–4 packages on nuget.org. Version handled by CI.

- ICancellationToken→CancellationToken migration.
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Platform and module version bumps can surface breaking API changes at runtime; export/import behavior changes only in cancellation plumbing but touches bulk data operations.
> 
> **Overview**
> **Stable 15** alignment: bumps **VirtoCommerce.Platform** and related module packages to **3.1039.0** (and matching Catalog, Store, Assets, Content, Customer versions) in project references and `module.manifest`.
> 
> Replaces platform **`ICancellationToken`** with **`System.Threading.CancellationToken`** on sitemap **export/import** (`SitemapExportImport`, `Module.ExportAsync` / `ImportAsync`) and threads the token through **Newtonsoft** `JsonTextWriter` / `JsonTextReader` async calls. Unit tests use **`CancellationToken.None`** instead of mocking `ICancellationToken`; **coverlet.collector** is updated to **10.0.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6748ee8c043770948f9f2b5b80ec44afca7b9da8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Sitemaps_3.1003.0-pr-91-b0b9.zip