### PR TITLE
VCST-5490: use BackgroundJobs

### DIFF
--- a/src/VirtoCommerce.SitemapsModule.Core/VirtoCommerce.SitemapsModule.Core.csproj
+++ b/src/VirtoCommerce.SitemapsModule.Core/VirtoCommerce.SitemapsModule.Core.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     
     <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1029.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1052.0" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1005.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.SitemapsModule.Data.MySql/VirtoCommerce.SitemapsModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.SitemapsModule.Data.MySql/VirtoCommerce.SitemapsModule.Data.MySql.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.SitemapsModule.Data\VirtoCommerce.SitemapsModule.Data.csproj" />

--- a/src/VirtoCommerce.SitemapsModule.Data.PostgreSql/VirtoCommerce.SitemapsModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.SitemapsModule.Data.PostgreSql/VirtoCommerce.SitemapsModule.Data.PostgreSql.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.SitemapsModule.Data\VirtoCommerce.SitemapsModule.Data.csproj" />

--- a/src/VirtoCommerce.SitemapsModule.Data.SqlServer/VirtoCommerce.SitemapsModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.SitemapsModule.Data.SqlServer/VirtoCommerce.SitemapsModule.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.SitemapsModule.Data\VirtoCommerce.SitemapsModule.Data.csproj" />

--- a/src/VirtoCommerce.SitemapsModule.Data/BackgroundJobs/SitemapProcessJob.cs
+++ b/src/VirtoCommerce.SitemapsModule.Data/BackgroundJobs/SitemapProcessJob.cs
@@ -2,8 +2,8 @@ using System;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
-using Hangfire;
 using Microsoft.Extensions.Logging;
 using VirtoCommerce.AssetsModule.Core.Assets;
 using VirtoCommerce.Platform.Core.Common;
@@ -46,7 +46,10 @@ public class SitemapExportToAssetsJob
         _blobUrlResolver = blobUrlResolver;
     }
 
-    public async Task ProcessAll(IJobCancellationToken cancellationToken)
+    // Takes a plain CancellationToken instead of Hangfire's IJobCancellationToken: that type came from the Hangfire
+    // package this module no longer references, so the parameter could not be kept. Breaking for any caller or
+    // override compiled against the old signature.
+    public async Task ProcessAll(CancellationToken cancellationToken = default)
     {
         var searchCriteria = AbstractTypeFactory<StoreSearchCriteria>.TryCreateInstance();
 

--- a/src/VirtoCommerce.SitemapsModule.Data/Jobs/SitemapDownloadJobHandler.cs
+++ b/src/VirtoCommerce.SitemapsModule.Data/Jobs/SitemapDownloadJobHandler.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.Platform.Core.Jobs;
+using VirtoCommerce.SitemapsModule.Data.BackgroundJobs;
+
+namespace VirtoCommerce.SitemapsModule.Data.Jobs
+{
+    /// <summary>
+    /// Packs a store's sitemap files into a downloadable archive, off the request thread.
+    /// </summary>
+    public class SitemapDownloadJobHandler(SitemapExportToAssetsJob job) : IBackgroundJobHandler<SitemapDownloadJobPayload>
+    {
+        public virtual Task Execute(SitemapDownloadJobPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return job.BackgroundDownload(payload.StoreId, payload.BaseUrl, payload.LocalTmpFolder, payload.SitemapIds, payload.Notification);
+        }
+    }
+}

--- a/src/VirtoCommerce.SitemapsModule.Data/Jobs/SitemapDownloadJobPayload.cs
+++ b/src/VirtoCommerce.SitemapsModule.Data/Jobs/SitemapDownloadJobPayload.cs
@@ -1,0 +1,24 @@
+using VirtoCommerce.SitemapsModule.Data.Model.PushNotifications;
+
+namespace VirtoCommerce.SitemapsModule.Data.Jobs
+{
+    /// <summary>
+    /// Payload of the background job that packs a store's sitemap files into a downloadable archive.
+    /// </summary>
+    public class SitemapDownloadJobPayload
+    {
+        public string StoreId { get; set; }
+
+        public string BaseUrl { get; set; }
+
+        public string LocalTmpFolder { get; set; }
+
+        public string[] SitemapIds { get; set; }
+
+        /// <summary>
+        /// The notification created by the request that started the job. Carried in the payload, as the Hangfire job
+        /// this replaces did, because the job reports its progress and final download URL against that same id.
+        /// </summary>
+        public SitemapDownloadNotification Notification { get; set; }
+    }
+}

--- a/src/VirtoCommerce.SitemapsModule.Data/Jobs/SitemapExportAllToAssetsJobHandler.cs
+++ b/src/VirtoCommerce.SitemapsModule.Data/Jobs/SitemapExportAllToAssetsJobHandler.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.Platform.Core.Jobs;
+using VirtoCommerce.SitemapsModule.Data.BackgroundJobs;
+
+namespace VirtoCommerce.SitemapsModule.Data.Jobs
+{
+    /// <summary>
+    /// Exports sitemaps to store assets for every store that has the export enabled. Target of the recurring schedule.
+    /// </summary>
+    public class SitemapExportAllToAssetsJobHandler(SitemapExportToAssetsJob job) : IBackgroundJobHandler<SitemapExportAllToAssetsJobPayload>
+    {
+        public virtual Task Execute(SitemapExportAllToAssetsJobPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return job.ProcessAll(cancellationToken);
+        }
+    }
+}

--- a/src/VirtoCommerce.SitemapsModule.Data/Jobs/SitemapExportAllToAssetsJobPayload.cs
+++ b/src/VirtoCommerce.SitemapsModule.Data/Jobs/SitemapExportAllToAssetsJobPayload.cs
@@ -1,0 +1,11 @@
+namespace VirtoCommerce.SitemapsModule.Data.Jobs
+{
+    /// <summary>
+    /// Payload of the recurring job that exports sitemaps for every store that has the export enabled. Carries no
+    /// data: the schedule fires with no arguments and the job discovers the stores itself. It exists because the job
+    /// API is payload-addressed, and it stays a class so a partner module can extend it via AbstractTypeFactory.
+    /// </summary>
+    public class SitemapExportAllToAssetsJobPayload
+    {
+    }
+}

--- a/src/VirtoCommerce.SitemapsModule.Data/Jobs/SitemapExportToAssetsJobHandler.cs
+++ b/src/VirtoCommerce.SitemapsModule.Data/Jobs/SitemapExportToAssetsJobHandler.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.Platform.Core.Jobs;
+using VirtoCommerce.SitemapsModule.Data.BackgroundJobs;
+
+namespace VirtoCommerce.SitemapsModule.Data.Jobs
+{
+    /// <summary>
+    /// Writes a store's sitemap files to its asset folder on demand, off the request thread.
+    /// </summary>
+    public class SitemapExportToAssetsJobHandler(SitemapExportToAssetsJob job) : IBackgroundJobHandler<SitemapExportToAssetsJobPayload>
+    {
+        public virtual Task Execute(SitemapExportToAssetsJobPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return job.BackgroundExportToAssets(payload.StoreId, payload.BaseUrl, payload.SitemapIds, payload.Notification);
+        }
+    }
+}

--- a/src/VirtoCommerce.SitemapsModule.Data/Jobs/SitemapExportToAssetsJobPayload.cs
+++ b/src/VirtoCommerce.SitemapsModule.Data/Jobs/SitemapExportToAssetsJobPayload.cs
@@ -1,0 +1,22 @@
+using VirtoCommerce.SitemapsModule.Data.Model.PushNotifications;
+
+namespace VirtoCommerce.SitemapsModule.Data.Jobs
+{
+    /// <summary>
+    /// Payload of the background job that writes a store's sitemap files to its asset folder on demand.
+    /// </summary>
+    public class SitemapExportToAssetsJobPayload
+    {
+        public string StoreId { get; set; }
+
+        public string BaseUrl { get; set; }
+
+        public string[] SitemapIds { get; set; }
+
+        /// <summary>
+        /// The notification created by the request that started the job. Carried in the payload, as the Hangfire job
+        /// this replaces did, because the job reports its progress and resulting asset URL against that same id.
+        /// </summary>
+        public SitemapExportToAssetNotification Notification { get; set; }
+    }
+}

--- a/src/VirtoCommerce.SitemapsModule.Data/VirtoCommerce.SitemapsModule.Data.csproj
+++ b/src/VirtoCommerce.SitemapsModule.Data/VirtoCommerce.SitemapsModule.Data.csproj
@@ -13,8 +13,7 @@
     <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1005.0" />
     <PackageReference Include="VirtoCommerce.ContentModule.Core" Version="3.1003.0" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1010.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1052.0" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/VirtoCommerce.SitemapsModule.Web/Controllers/Api/SitemapsModuleApiController.cs
+++ b/src/VirtoCommerce.SitemapsModule.Web/Controllers/Api/SitemapsModuleApiController.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Threading.Tasks;
-using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -8,13 +7,14 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using VirtoCommerce.Platform.Core;
 using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.Platform.Core.PushNotifications;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.SitemapsModule.Core;
 using VirtoCommerce.SitemapsModule.Core.Models;
 using VirtoCommerce.SitemapsModule.Core.Models.Search;
 using VirtoCommerce.SitemapsModule.Core.Services;
-using VirtoCommerce.SitemapsModule.Data.BackgroundJobs;
+using VirtoCommerce.SitemapsModule.Data.Jobs;
 using VirtoCommerce.SitemapsModule.Data.Model.PushNotifications;
 using VirtoCommerce.SitemapsModule.Data.Services;
 using VirtoCommerce.SitemapsModule.Web.Extensions;
@@ -228,7 +228,14 @@ namespace VirtoCommerce.SitemapsModule.Web.Controllers.Api
 
             var localTmpFolder = _hostingEnvironment.MapPath(Path.Combine("~/", _platformOptions.LocalUploadFolderPath, "tmp"));
 
-            BackgroundJob.Enqueue<SitemapExportToAssetsJob>(job => job.BackgroundDownload(storeId, baseUrl, localTmpFolder, sitemapIds, notification));
+            var payload = AbstractTypeFactory<SitemapDownloadJobPayload>.TryCreateInstance();
+            payload.StoreId = storeId;
+            payload.BaseUrl = baseUrl;
+            payload.LocalTmpFolder = localTmpFolder;
+            payload.SitemapIds = sitemapIds;
+            payload.Notification = notification;
+
+            await BackgroundJob.Enqueue<SitemapDownloadJobHandler>(payload);
 
             return Ok(notification);
         }
@@ -246,7 +253,13 @@ namespace VirtoCommerce.SitemapsModule.Web.Controllers.Api
 
             await _notifier.SendAsync(notification);
 
-            BackgroundJob.Enqueue<SitemapExportToAssetsJob>(job => job.BackgroundExportToAssets(storeId, baseUrl, sitemapIds, notification));
+            var payload = AbstractTypeFactory<SitemapExportToAssetsJobPayload>.TryCreateInstance();
+            payload.StoreId = storeId;
+            payload.BaseUrl = baseUrl;
+            payload.SitemapIds = sitemapIds;
+            payload.Notification = notification;
+
+            await BackgroundJob.Enqueue<SitemapExportToAssetsJobHandler>(payload);
 
             return Ok(notification);
         }

--- a/src/VirtoCommerce.SitemapsModule.Web/Module.cs
+++ b/src/VirtoCommerce.SitemapsModule.Web/Module.cs
@@ -1,14 +1,14 @@
-using System;
+using System;
 using System.Threading;
 using System.IO;
 using System.Threading.Tasks;
-using Hangfire;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.ExportImport;
+using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.Platform.Core.Settings;
@@ -16,11 +16,11 @@ using VirtoCommerce.Platform.Data.Extensions;
 using VirtoCommerce.Platform.Data.MySql.Extensions;
 using VirtoCommerce.Platform.Data.PostgreSql.Extensions;
 using VirtoCommerce.Platform.Data.SqlServer.Extensions;
-using VirtoCommerce.Platform.Hangfire;
 using VirtoCommerce.SitemapsModule.Core;
 using VirtoCommerce.SitemapsModule.Core.Services;
 using VirtoCommerce.SitemapsModule.Data.BackgroundJobs;
 using VirtoCommerce.SitemapsModule.Data.ExportImport;
+using VirtoCommerce.SitemapsModule.Data.Jobs;
 using VirtoCommerce.SitemapsModule.Data.MySql;
 using VirtoCommerce.SitemapsModule.Data.PostgreSql;
 using VirtoCommerce.SitemapsModule.Data.Repositories;
@@ -74,6 +74,18 @@ namespace VirtoCommerce.SitemapsModule.Web
             serviceCollection.AddTransient<ISitemapGenerator, SitemapXmlGenerator>();
             serviceCollection.AddTransient<ISitemapXmlGenerator, SitemapXmlGenerator>();
             serviceCollection.AddTransient<SitemapExportImport>();
+
+            serviceCollection.AddTransient<SitemapExportToAssetsJob>();
+            serviceCollection.AddBackgroundJob<SitemapDownloadJobHandler, SitemapDownloadJobPayload>();
+            serviceCollection.AddBackgroundJob<SitemapExportToAssetsJobHandler, SitemapExportToAssetsJobPayload>();
+
+            // Schedule periodic sitemap export. Registered here rather than in PostInitialize: the schedule is now a
+            // DI registration the engine module picks up, not an imperative call on a resolved service.
+            serviceCollection.AddRecurringJob<SitemapExportAllToAssetsJobHandler, SitemapExportAllToAssetsJobPayload>(schedule => schedule
+                .WithId(nameof(SitemapExportAllToAssetsJobHandler))
+                .FromSettings(
+                    ModuleConstants.Settings.General.EnableExportToAssetsJob,
+                    ModuleConstants.Settings.General.ExportToAssetsJobCronExpression));
         }
 
         public void PostInitialize(IApplicationBuilder appBuilder)
@@ -97,16 +109,6 @@ namespace VirtoCommerce.SitemapsModule.Web
 
             var permissionsRegistrar = appBuilder.ApplicationServices.GetRequiredService<IPermissionsRegistrar>();
             permissionsRegistrar.RegisterPermissions(ModuleInfo.Id, "Sitemaps", ModuleConstants.Security.Permissions.AllPermissions);
-
-            //Schedule periodic image processing job
-            var recurringJobService = appBuilder.ApplicationServices.GetService<IRecurringJobService>();
-
-            recurringJobService.WatchJobSetting(
-                new SettingCronJobBuilder()
-                    .SetEnablerSetting(ModuleConstants.Settings.General.EnableExportToAssetsJob)
-                    .SetCronSetting(ModuleConstants.Settings.General.ExportToAssetsJobCronExpression)
-                    .ToJob<SitemapExportToAssetsJob>(x => x.ProcessAll(JobCancellationToken.Null))
-                    .Build());
         }
 
         public void Uninstall()

--- a/src/VirtoCommerce.SitemapsModule.Web/module.manifest
+++ b/src/VirtoCommerce.SitemapsModule.Web/module.manifest
@@ -7,7 +7,6 @@
   <platformVersion>3.1052.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
-    <dependency id="VirtoCommerce.BackgroundJobs" version="3.1050.0" />
     <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
     <dependency id="VirtoCommerce.Content" version="3.1003.0" />
     <dependency id="VirtoCommerce.Core" version="3.1007.0" />

--- a/src/VirtoCommerce.SitemapsModule.Web/module.manifest
+++ b/src/VirtoCommerce.SitemapsModule.Web/module.manifest
@@ -4,9 +4,10 @@
   <version>3.1004.0</version>
   <version-tag />
 
-  <platformVersion>3.1039.0</platformVersion>
+  <platformVersion>3.1052.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
+    <dependency id="VirtoCommerce.BackgroundJobs" version="3.1050.0" />
     <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
     <dependency id="VirtoCommerce.Content" version="3.1003.0" />
     <dependency id="VirtoCommerce.Core" version="3.1007.0" />


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5490
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Sitemaps_3.1004.0-pr-92-2e95.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches how all sitemap background and scheduled export runs are scheduled and executed; ProcessAll’s public signature is intentionally breaking for anyone still on Hangfire types.
> 
> **Overview**
> Migrates sitemap download, on-demand export to store assets, and scheduled export-all off **Hangfire** onto Virto Commerce **3.1052**’s platform background jobs (`IBackgroundJobHandler`, typed payloads, `BackgroundJob.Enqueue`). The **VirtoCommerce.Platform.Hangfire** package reference is removed.
> 
> API endpoints now build `SitemapDownloadJobPayload` / `SitemapExportToAssetsJobPayload` (including the same push-notification instances as before) and enqueue the new handlers instead of expression-based `BackgroundJob.Enqueue<SitemapExportToAssetsJob>(...)`. Module startup registers `AddBackgroundJob` for those handlers and moves the recurring export from `PostInitialize` + `IRecurringJobService.WatchJobSetting` to `AddRecurringJob<SitemapExportAllToAssetsJobHandler, ...>` wired to the existing enable/cron settings.
> 
> `SitemapExportToAssetsJob.ProcessAll` now takes **`CancellationToken`** instead of Hangfire’s **`IJobCancellationToken`**—a **breaking** change for any external caller or subclass compiled against the old signature. Platform package references and `module.manifest` **platformVersion** are bumped to **3.1052.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e95c020c77312a08c3d6dc7e9d158e3135cda3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->